### PR TITLE
Show a toast when test run finished

### DIFF
--- a/NUnitLite.MonoDroid.Runner/TestRunnerActivity.cs
+++ b/NUnitLite.MonoDroid.Runner/TestRunnerActivity.cs
@@ -108,6 +108,7 @@ namespace NUnitLite.MonoDroid
                         ShowErrorDialog(ex);
                     }
                 }
+                RunOnUiThread(() => Toast.MakeText(this, "Test run finished", ToastLength.Short).Show());
             });
         }
 

--- a/NUnitLite.MonoDroid.Runner/TestRunnerExpandableActivity.cs
+++ b/NUnitLite.MonoDroid.Runner/TestRunnerExpandableActivity.cs
@@ -110,6 +110,7 @@ namespace NUnitLite.MonoDroid
                         ShowErrorDialog(ex);
                     }
                 }
+                RunOnUiThread(() => Toast.MakeText(this, "Test run finished", ToastLength.Short).Show());
             });
         }
 


### PR DESCRIPTION
Useful when there's a long test run so that you don't have to keep scrolling to find out if it's finished yet
